### PR TITLE
Pairing can be very slow and sometimes iOS will send a TCP reset

### DIFF
--- a/src/arduino_homekit_server.cpp
+++ b/src/arduino_homekit_server.cpp
@@ -3010,11 +3010,19 @@ client_context_t* homekit_server_accept_client(homekit_server_t *server) {
 			wifiClient->localIP().toString().c_str(), wifiClient->localPort(),
 			wifiClient->remoteIP().toString().c_str(), wifiClient->remotePort());
 
-	wifiClient->keepAlive(HOMEKIT_SOCKET_KEEPALIVE_IDLE_SEC,
-        HOMEKIT_SOCKET_KEEPALIVE_INTERVAL_SEC, HOMEKIT_SOCKET_KEEPALIVE_IDLE_COUNT);
 	wifiClient->setNoDelay(true);
 	wifiClient->setSync(true);
-	wifiClient->setTimeout(HOMEKIT_SOCKET_TIMEOUT);
+	if (server->paired) {
+		wifiClient->keepAlive(HOMEKIT_SOCKET_KEEPALIVE_IDLE_SEC,
+			HOMEKIT_SOCKET_KEEPALIVE_INTERVAL_SEC, HOMEKIT_SOCKET_KEEPALIVE_IDLE_COUNT);
+		wifiClient->setTimeout(HOMEKIT_SOCKET_TIMEOUT);
+		INFO("Setting Timeout to 500ms");
+	} else {
+		// During the pairing process, relax the session timeout and be more agressive about keepalives
+		wifiClient->keepAlive(5, 5, 20);
+		wifiClient->setTimeout(90000);
+		INFO("Setting Timeout to 90 s");
+	}
 
 	client_context_t *context = client_context_new(wifiClient);
 	context->server = server;

--- a/src/wolfcrypt/src/integer.c
+++ b/src/wolfcrypt/src/integer.c
@@ -3535,7 +3535,7 @@ int s_mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y, int redmode)
      * call `yield()` to run WiFi task,
      * to prevent WiFi disconnection while heavy crypto computing.
      */
-	yield();
+    optimistic_yield(1000);
     /* grab next digit as required */
     if (--bitcnt == 0) {
       /* if digidx == -1 we are out of digits */

--- a/src/wolfcrypt/src/srp.c
+++ b/src/wolfcrypt/src/srp.c
@@ -647,6 +647,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
         r = mp_read_unsigned_bin(&temp1, srp->k, digestSz);
         if (!r) r = mp_iszero(&temp1) == MP_YES ? SRP_BAD_KEY_E : 0;
         if (!r) r = mp_exptmod(&srp->g, &srp->auth, &srp->N, &temp2);
+        optimistic_yield(1000);
         if (!r) r = mp_mulmod(&temp1, &temp2, &srp->N, &s);
         if (!r) r = mp_read_unsigned_bin(&temp2, serverPubKey, serverPubKeySz);
         if (!r) r = mp_iszero(&temp2) == MP_YES ? SRP_BAD_KEY_E : 0;
@@ -659,10 +660,12 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
 
         /* secret = temp1 ^ temp2 % N */
         if (!r) r = mp_exptmod(&temp1, &temp2, &srp->N, &s);
+        optimistic_yield(1000);
 
     } else if (!r && srp->side == SRP_SERVER_SIDE) {
         /* temp1 = v ^ u % N */
         r = mp_exptmod(&srp->auth, &u, &srp->N, &temp1);
+        optimistic_yield(1000);
 
         /* temp2 = A * temp1 % N; rejects A == 0, A >= N */
         if (!r) r = mp_read_unsigned_bin(&s, clientPubKey, clientPubKeySz);
@@ -678,6 +681,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
 
         /* secret = temp2 * b % N */
         if (!r) r = mp_exptmod(&temp2, &srp->priv, &srp->N, &s);
+        optimistic_yield(1000);
     }
 
     /* building session key from secret */


### PR DESCRIPTION
Attempt keep the session alive while pairing
Add optimistic_yields to try and prevent the session from timing out